### PR TITLE
Bumped Seaport to 1.0.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,11 +18,11 @@
   },
   "dependencies": {
     "@imtbl/imx-sdk": "^1.24.1",
-    "ethers": "^5.0.26",
-    "ethereumjs-util": "^7.0.10",
-    "@opensea/seaport-js": "^1.0.4",
+    "@opensea/seaport-js": "^1.0.8",
     "@solana/web3.js": "^1.35.1",
     "axios": "^0.21.1",
+    "ethereumjs-util": "^7.0.10",
+    "ethers": "^5.0.26",
     "eventemitter3": "^4.0.7",
     "web3": "^1.7.1"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -618,10 +618,10 @@
   resolved "https://registry.yarnpkg.com/@noble/secp256k1/-/secp256k1-1.6.3.tgz#7eed12d9f4404b416999d0c87686836c4c5c9b94"
   integrity sha512-T04e4iTurVy7I8Sw4+c5OSN9/RkPlo1uKxAomtxQNLq8j1uPAqnsqG1bqvY3Jv7c13gyr6dui0zmh/I3+f/JaQ==
 
-"@opensea/seaport-js@^1.0.4":
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/@opensea/seaport-js/-/seaport-js-1.0.5.tgz#f48ebf5e3bc6ff5627502616598b401c6eaf352a"
-  integrity sha512-WgK3Grdqf5PEQWMlSFiSFaL/j8vlJ3feSjn+frFEO0QH2MuqwlFBRUGwqK4l09o5ZtZDRRTMafgrYC6BOgBY4A==
+"@opensea/seaport-js@^1.0.8":
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/@opensea/seaport-js/-/seaport-js-1.0.8.tgz#7609e24b6e8b30ebea4dba149379273aa0a271f1"
+  integrity sha512-xug0bTfHbu/Oz78hg0cXOPk12yW8EhvXzlqXBrrFkQCzk/6xU245+3oTVg/kHt2oToym0OYUTgREdxU998zRxA==
   dependencies:
     "@0xsequence/multicall" "^0.39.0"
     ethers "^5.6.7"


### PR DESCRIPTION
I'm not exactly sure why, but I get the following provider related error unless using a newer SeaPort.
![image](https://user-images.githubusercontent.com/7354598/199084263-9f31fa84-7ae9-47de-a77d-f314bcdd85ff.png)


